### PR TITLE
Support for checking both Version and Build together

### DIFF
--- a/Sources/MaintenanceKit/MaintenanceProtocols.swift
+++ b/Sources/MaintenanceKit/MaintenanceProtocols.swift
@@ -14,6 +14,9 @@ public enum VersionCheckMethod {
     
     /// The Build Number (CFBundleVersion) of the app
     case build
+    
+    /// Support checking both the version and build number
+    case both
 }
 
 /// Upgrade Check Protocol

--- a/Sources/MaintenanceKit/MaintenanceService.swift
+++ b/Sources/MaintenanceKit/MaintenanceService.swift
@@ -131,6 +131,26 @@ public struct MaintenanceService {
                     }
                     // No Update needed
                     completion(.success(.init(updateAvailable: false, isOlderThanMinimumVersion: false, details: platform)))
+                    
+                case .both:
+                    /// **Version & Build Check**
+                    /// Check if we have an update available. We use the current version against the latest version.
+                    /// We also check if the minimum version and build is newer than the current version and build.
+                    /// If it is, we are using a version that is super outdated and being sunset, meaning it's
+                    /// dead and no longer supported.
+                    let currentVersion = Version(from: app.currentVersion)
+                    
+                    if platform.latestVersion > currentVersion && platform.latestBuild > app.currentBuild {
+                        // We need to update
+                        completion(.success(.init(
+                            updateAvailable: true,
+                            isOlderThanMinimumVersion: platform.latestVersion > currentVersion && platform.minimumBuild > app.currentBuild,
+                            details: platform))
+                        )
+                        return
+                    }
+                    // No Update needed
+                    completion(.success(.init(updateAvailable: false, isOlderThanMinimumVersion: false, details: platform)))
                 }
                 
             case .failure(let error):

--- a/Tests/MaintenanceKitTests/MaintenanceKitTests.swift
+++ b/Tests/MaintenanceKitTests/MaintenanceKitTests.swift
@@ -116,6 +116,11 @@ final class MaintenanceKitTests: XCTestCase {
         let currentVersion = Version(from: "5.7.3")
         XCTAssertEqual(latestVersion, currentVersion)
         XCTAssertFalse(latestVersion > currentVersion)
+        
+        let latestBuild = 100
+        let currentBuild = 99
+        
+        XCTAssertFalse(latestVersion > currentVersion && latestBuild > currentBuild)
     }
 
     static var allTests = [


### PR DESCRIPTION
This adds a 3rd option for comparing against versio nand build.

ps-id: F28D788F-FA6A-4295-917B-C98537DEA07B